### PR TITLE
add a generic cache for geocoders #6

### DIFF
--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -94,7 +94,7 @@ class ArcGIS(Geocoder):
         :param str domain: Domain where the target ArcGIS service
             is hosted.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/arcgis.py
+++ b/geopy/geocoders/arcgis.py
@@ -44,7 +44,9 @@ class ArcGIS(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             auth_domain='www.arcgis.com',
-            domain='geocode.arcgis.com'
+            domain='geocode.arcgis.com',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -91,6 +93,18 @@ class ArcGIS(Geocoder):
 
         :param str domain: Domain where the target ArcGIS service
             is hosted.
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -99,6 +113,8 @@ class ArcGIS(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         if username or password or referer:
             if not (username and password and referer):

--- a/geopy/geocoders/azure.py
+++ b/geopy/geocoders/azure.py
@@ -55,7 +55,7 @@ class AzureMaps(TomTom):
         :param str domain: Domain where the target Azure Maps service
             is hosted.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/azure.py
+++ b/geopy/geocoders/azure.py
@@ -24,7 +24,9 @@ class AzureMaps(TomTom):
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
-            domain='atlas.microsoft.com'
+            domain='atlas.microsoft.com',
+            cache=None,
+            cache_expire=None
     ):
         """
         :param str subscription_key: Azure Maps subscription key.
@@ -52,6 +54,18 @@ class AzureMaps(TomTom):
 
         :param str domain: Domain where the target Azure Maps service
             is hosted.
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             api_key=subscription_key,
@@ -62,6 +76,8 @@ class AzureMaps(TomTom):
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
             domain=domain,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
     def _geocode_params(self, formatted_query):

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -39,7 +39,9 @@ class Baidu(Geocoder):
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
-            security_key=None
+            security_key=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -71,6 +73,18 @@ class Baidu(Geocoder):
         :param str security_key: The security key (SK) to calculate
             the SN parameter in request if authentication setting requires
             (http://lbsyun.baidu.com/index.php?title=lbscloud/api/appendix).
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -79,6 +93,8 @@ class Baidu(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.api = '%s://api.map.baidu.com%s' % (self.scheme, self.api_path)

--- a/geopy/geocoders/baidu.py
+++ b/geopy/geocoders/baidu.py
@@ -74,7 +74,7 @@ class Baidu(Geocoder):
             the SN parameter in request if authentication setting requires
             (http://lbsyun.baidu.com/index.php?title=lbscloud/api/appendix).
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -27,7 +27,9 @@ class BANFrance(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -53,6 +55,16 @@ class BANFrance(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+
             .. versionadded:: 2.0
 
         """
@@ -63,6 +75,8 @@ class BANFrance(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.domain = domain.strip('/')
 
@@ -165,6 +179,7 @@ class BANFrance(Geocoder):
         latitude = feature.get('geometry', {}).get('coordinates', [])[1]
         longitude = feature.get('geometry', {}).get('coordinates', [])[0]
         placename = feature.get('properties', {}).get('label')
+        postcode = feature.get('properties', {}).get('postcode')
 
         return Location(placename, (latitude, longitude), feature)
 

--- a/geopy/geocoders/banfrance.py
+++ b/geopy/geocoders/banfrance.py
@@ -55,7 +55,7 @@ class BANFrance(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -30,11 +30,12 @@ try:
     from diskcache import Cache
     import os
     from tempfile import gettempdir
-    # the role of cache expiration is to reflect the fact databases of geocoders can be updated.
-    _DEFAULT_CACHE_EXPIRE = 60*60*24*30 # 30 days
     diskcache_available = True
 except ImportError:
     diskcache_available = False
+
+# the role of cache expiration is to reflect the fact databases of geocoders can be updated.
+_DEFAULT_CACHE_EXPIRE = 60*60*24*30 # 30 days
 
 __all__ = (
     "Geocoder",

--- a/geopy/geocoders/base.py
+++ b/geopy/geocoders/base.py
@@ -25,6 +25,17 @@ from geopy.exc import (
 from geopy.point import Point
 from geopy.util import __version__, logger
 
+
+try:
+    from diskcache import Cache
+    import os
+    from tempfile import gettempdir
+    # the role of cache expiration is to reflect the fact databases of geocoders can be updated.
+    _DEFAULT_CACHE_EXPIRE = 60*60*24*30 # 30 days
+    diskcache_available = True
+except ImportError:
+    diskcache_available = False
+
 __all__ = (
     "Geocoder",
     "options",
@@ -37,7 +48,6 @@ _DEFAULT_ADAPTER_CLASS = next(
     for adapter_cls in (RequestsAdapter, URLLibAdapter,)
     if adapter_cls.is_available
 )
-
 
 class options:
     """The `options` object contains default configuration values for
@@ -166,6 +176,11 @@ class options:
 
         default_user_agent
             User-Agent header to send with the requests to geocoder API.
+
+        default_cache_expire
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
     """
 
     # Please keep the attributes sorted (Sphinx sorts them in the rendered
@@ -185,7 +200,8 @@ class options:
     default_ssl_context = None
     default_timeout = 1
     default_user_agent = _DEFAULT_USER_AGENT
-
+    default_cache = True
+    default_cache_expire = _DEFAULT_CACHE_EXPIRE
 
 # Create an object which `repr` returns 'DEFAULT_SENTINEL'. Sphinx (docs) uses
 # this value when generating method's signature.
@@ -224,7 +240,9 @@ class Geocoder:
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         self.scheme = scheme or options.default_scheme
         if self.scheme not in ('http', 'https'):
@@ -257,6 +275,25 @@ class Geocoder:
                 "Adapter %r must extend either BaseSyncAdapter or BaseAsyncAdapter"
                 % (type(self.adapter),)
             )
+        
+        self.cache = None
+        if diskcache_available:
+            if isinstance(cache, Cache):
+                self.cache = cache
+            elif cache is None or cache is True:
+                path = os.path.join(gettempdir(), "geocodepy", "cache", self.__class__.__name__)
+                print("allocating a cache for", self.__class__.__name__, "in", path)
+                self.cache = Cache(path, eviction_policy='least-frequently-used', statistics=True)
+            if self.cache is not None:
+                # invalidate cached results at init, to save space and get quicker results
+                self.cache.expire()
+            self.cache_expire = options.default_cache_expire if cache_expire is None else int(cache_expire)
+        elif cache is not None:
+            raise ConfigurationError("please install diskcache to activate cache")
+
+    def clear_cache(self):
+        if self.cache is not None:
+            self.cache.clear()
 
     def __enter__(self):
         """Context manager for synchronous adapters. At exit all
@@ -360,20 +397,27 @@ class Geocoder:
         if headers:
             req_headers.update(headers)
 
+        print("headers:", req_headers)
+        print("url:", url)
+
         timeout = (timeout if timeout is not DEFAULT_SENTINEL
                    else self.timeout)
 
         try:
-            if is_json:
-                result = self.adapter.get_json(url, timeout=timeout, headers=req_headers)
-            else:
-                result = self.adapter.get_text(url, timeout=timeout, headers=req_headers)
+            result = self.cache.get(url, None) if self.cache is not None else None
+            if result is None :
+                if is_json:
+                    result = self.adapter.get_json(url, timeout=timeout, headers=req_headers)
+                else:
+                    result = self.adapter.get_text(url, timeout=timeout, headers=req_headers)
             if self.__run_async:
                 async def fut():
                     try:
                         res = callback(await result)
                         if inspect.isawaitable(res):
                             res = await res
+                        if self.cache is not None:
+                            self.cache.set(url, result, expire=self.cache_expire)
                         return res
                     except Exception as error:
                         res = self._adapter_error_handler(error)
@@ -383,6 +427,8 @@ class Geocoder:
 
                 return fut()
             else:
+                if self.cache is not None:
+                    self.cache.set(url, result, expire=self.cache_expire)
                 return callback(result)
         except Exception as error:
             res = self._adapter_error_handler(error)
@@ -414,11 +460,21 @@ class Geocoder:
             if res is NONE_RESULT:
                 return NONE_RESULT
 
+    def __del__(self):
+        if self.cache is not None:
+            try:
+                hits, misses = self.cache.stats(enable=False, reset=True)
+                print("closing cache for", self.__class__.__name__, hits, "hits,", misses, "misses")
+                self.cache.expire()
+            finally:
+                self.cache.close()
+
     # def geocode(self, query, *, exactly_one=True, timeout=DEFAULT_SENTINEL):
     #     raise NotImplementedError()
 
     # def reverse(self, query, *, exactly_one=True, timeout=DEFAULT_SENTINEL):
     #     raise NotImplementedError()
+
 
 
 def _format_coordinate(coordinate):

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -78,7 +78,7 @@ class Bing(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/bing.py
+++ b/geopy/geocoders/bing.py
@@ -45,6 +45,8 @@ class Bing(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain='dev.virtualearth.net',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -75,6 +77,18 @@ class Bing(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -83,6 +97,8 @@ class Bing(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.geocode_api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -58,7 +58,7 @@ class DataBC(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/databc.py
+++ b/geopy/geocoders/databc.py
@@ -28,6 +28,8 @@ class DataBC(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain='geocoder.api.gov.bc.ca',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -55,6 +57,18 @@ class DataBC(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -63,6 +77,8 @@ class DataBC(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api = '%s://%s%s' % (self.scheme, domain, self.geocode_path)
 

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -53,7 +53,7 @@ class GeocodeEarth(Pelias):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/geocodeearth.py
+++ b/geopy/geocoders/geocodeearth.py
@@ -25,7 +25,9 @@ class GeocodeEarth(Pelias):
             user_agent=None,
             scheme=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
         :param str api_key: Geocode.earth API key, required.
@@ -51,8 +53,17 @@ class GeocodeEarth(Pelias):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-            .. versionadded:: 2.0
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
 
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             api_key=api_key,
@@ -63,4 +74,6 @@ class GeocodeEarth(Pelias):
             scheme=scheme,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )

--- a/geopy/geocoders/geocodio.py
+++ b/geopy/geocoders/geocodio.py
@@ -47,6 +47,8 @@ class Geocodio(Geocoder):
         ssl_context=DEFAULT_SENTINEL,
         adapter_factory=None,
         domain=None,
+        cache=None,
+        cache_expire=None
     ):
         """
         :param str api_key:
@@ -73,6 +75,16 @@ class Geocodio(Geocoder):
 
         :param str domain: base api domain
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
             .. versionadded:: 2.4
         """
         super().__init__(
@@ -82,6 +94,8 @@ class Geocodio(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         if domain:

--- a/geopy/geocoders/geocodio.py
+++ b/geopy/geocoders/geocodio.py
@@ -75,7 +75,7 @@ class Geocodio(Geocoder):
 
         :param str domain: base api domain
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/geokeo.py
+++ b/geopy/geocoders/geokeo.py
@@ -37,7 +37,9 @@ class Geokeo(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -67,6 +69,17 @@ class Geokeo(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -75,6 +88,8 @@ class Geokeo(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/geokeo.py
+++ b/geopy/geocoders/geokeo.py
@@ -69,7 +69,7 @@ class Geokeo(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -76,7 +76,7 @@ class Geolake(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/geolake.py
+++ b/geopy/geocoders/geolake.py
@@ -42,7 +42,9 @@ class Geolake(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -74,6 +76,17 @@ class Geolake(Geocoder):
 
             .. versionadded:: 2.0
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -82,6 +95,8 @@ class Geolake(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -84,7 +84,7 @@ class GeoNames(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/geonames.py
+++ b/geopy/geocoders/geonames.py
@@ -46,6 +46,8 @@ class GeoNames(Geocoder):
             adapter_factory=None,
             scheme='http',
             domain='api.geonames.org',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -81,6 +83,18 @@ class GeoNames(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -89,6 +103,8 @@ class GeoNames(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.username = username
 

--- a/geopy/geocoders/google.py
+++ b/geopy/geocoders/google.py
@@ -100,7 +100,7 @@ class GoogleV3(Geocoder):
 
         :param str channel: If using premier, the channel identifier.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/google.py
+++ b/geopy/geocoders/google.py
@@ -48,7 +48,9 @@ class GoogleV3(Geocoder):
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
-            channel=''
+            channel='',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -97,6 +99,18 @@ class GoogleV3(Geocoder):
             .. versionadded:: 2.0
 
         :param str channel: If using premier, the channel identifier.
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -105,6 +119,8 @@ class GoogleV3(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         if client_id and not secret_key:
             raise ConfigurationError('Must provide secret_key with client_id.')

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -57,7 +57,9 @@ class Here(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -107,6 +109,18 @@ class Here(Geocoder):
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
             .. versionadded:: 2.0
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -115,6 +129,8 @@ class Here(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         is_apikey = bool(apikey)
         is_app_code = app_id and app_code
@@ -420,6 +436,8 @@ class HereV7(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain="search.hereapi.com",
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -449,6 +467,18 @@ class HereV7(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -457,6 +487,8 @@ class HereV7(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.apikey = apikey

--- a/geopy/geocoders/here.py
+++ b/geopy/geocoders/here.py
@@ -110,7 +110,7 @@ class Here(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
@@ -468,7 +468,7 @@ class HereV7(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -34,7 +34,9 @@ class IGNFrance(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -83,6 +85,16 @@ class IGNFrance(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
             .. versionadded:: 2.0
         """  # noqa
         
@@ -93,6 +105,8 @@ class IGNFrance(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         if api_key or username or password or referer:
@@ -132,7 +146,6 @@ class IGNFrance(Geocoder):
         :param int limit: Defines the maximum number of items in the
             response structure. If not provided and there are multiple
             results the BAN API will return 10 results by default.
-            This will be reset to one if ``exactly_one`` is True.
 
         :param str index: The index to use for the geocoding.
             It can be `address` for postal address, `parcel` for cadastral 
@@ -195,10 +208,6 @@ class IGNFrance(Geocoder):
         :type query: :class:`geopy.point.Point`, list or tuple of ``(latitude,
             longitude)``, or string as ``"%(latitude)s, %(longitude)s"``.
 
-        :param list reverse_geocode_preference: Enable to set expected results
-            type. It can be `StreetAddress` or `PositionOfInterest`.
-            Default is set to `StreetAddress`.
-
         :param str index: The index to use for the geocoding.
             It can be `address` for postal address, `parcel` for cadastral 
             parcel, `poi` for point of interest. You can also combine them
@@ -211,11 +220,6 @@ class IGNFrance(Geocoder):
         :param int limit: Defines the maximum number of items in the
             response structure. If not provided and there are multiple
             results the BAN API will return 10 results by default.
-            This will be reset to one if ``exactly_one`` is True.
-
-        :param str filtering: Provide string that help setting geocoder
-            filter. It contains an XML string. See examples in documentation
-            and ignfrance.py file in directory tests.
 
         :param bool exactly_one: Return one result or a list of results, if
             available.

--- a/geopy/geocoders/ignfrance.py
+++ b/geopy/geocoders/ignfrance.py
@@ -85,7 +85,7 @@ class IGNFrance(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -66,7 +66,7 @@ class MapBox(Geocoder):
 
             .. versionadded:: 2.3
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/mapbox.py
+++ b/geopy/geocoders/mapbox.py
@@ -29,7 +29,9 @@ class MapBox(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain='api.mapbox.com',
-            referer=None
+            referer=None,
+            cache=None,
+            cache_expire=None
     ):
         """
         :param str api_key: The API key required by Mapbox to perform
@@ -63,6 +65,18 @@ class MapBox(Geocoder):
             mapbox tokens.
 
             .. versionadded:: 2.3
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -71,6 +85,8 @@ class MapBox(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.domain = domain.strip('/')

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -35,7 +35,9 @@ class MapQuest(Geocoder):
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
-            domain='www.mapquestapi.com'
+            domain='www.mapquestapi.com',
+            cache=None,
+            cache_expire=None
     ):
         """
         :param str api_key: The API key required by Mapquest to perform
@@ -64,6 +66,18 @@ class MapQuest(Geocoder):
             .. versionadded:: 2.0
 
         :param str domain: base api domain for mapquest
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -72,6 +86,8 @@ class MapQuest(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/mapquest.py
+++ b/geopy/geocoders/mapquest.py
@@ -67,7 +67,7 @@ class MapQuest(Geocoder):
 
         :param str domain: base api domain for mapquest
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/maptiler.py
+++ b/geopy/geocoders/maptiler.py
@@ -60,7 +60,7 @@ class MapTiler(Geocoder):
 
         :param str domain: base api domain for Maptiler
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/maptiler.py
+++ b/geopy/geocoders/maptiler.py
@@ -28,7 +28,9 @@ class MapTiler(Geocoder):
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
-            domain='api.maptiler.com'
+            domain='api.maptiler.com',
+            cache=None,
+            cache_expire=None
     ):
         """
         :param str api_key: The API key required by Maptiler to perform
@@ -57,6 +59,18 @@ class MapTiler(Geocoder):
             .. versionadded:: 2.0
 
         :param str domain: base api domain for Maptiler
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -65,6 +79,8 @@ class MapTiler(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.domain = domain.strip('/')

--- a/geopy/geocoders/nominatim.py
+++ b/geopy/geocoders/nominatim.py
@@ -91,7 +91,7 @@ class Nominatim(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/nominatim.py
+++ b/geopy/geocoders/nominatim.py
@@ -59,7 +59,9 @@ class Nominatim(Geocoder):
             scheme=None,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
             # Make sure to synchronize the changes of this signature in the
             # inheriting classes (e.g. PickPoint).
     ):
@@ -88,6 +90,18 @@ class Nominatim(Geocoder):
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
             .. versionadded:: 2.0
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -96,6 +110,8 @@ class Nominatim(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.domain = domain.strip('/')

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -67,7 +67,7 @@ class OpenCage(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/opencage.py
+++ b/geopy/geocoders/opencage.py
@@ -33,7 +33,9 @@ class OpenCage(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -64,6 +66,18 @@ class OpenCage(Geocoder):
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
             .. versionadded:: 2.0
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -72,6 +86,8 @@ class OpenCage(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -63,7 +63,7 @@ class OpenMapQuest(Nominatim):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/openmapquest.py
+++ b/geopy/geocoders/openmapquest.py
@@ -31,7 +31,9 @@ class OpenMapQuest(Nominatim):
             scheme=None,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -60,6 +62,18 @@ class OpenMapQuest(Nominatim):
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
             .. versionadded:: 2.0
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             timeout=timeout,
@@ -69,6 +83,8 @@ class OpenMapQuest(Nominatim):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
 

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -32,7 +32,9 @@ class Pelias(Geocoder):
             user_agent=None,
             scheme=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
             # Make sure to synchronize the changes of this signature in the
             # inheriting classes (e.g. GeocodeEarth).
     ):
@@ -62,6 +64,17 @@ class Pelias(Geocoder):
 
             .. versionadded:: 2.0
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -70,6 +83,8 @@ class Pelias(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/pelias.py
+++ b/geopy/geocoders/pelias.py
@@ -64,7 +64,7 @@ class Pelias(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -67,7 +67,7 @@ class Photon(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/photon.py
+++ b/geopy/geocoders/photon.py
@@ -36,7 +36,9 @@ class Photon(Geocoder):
             domain='photon.komoot.io',
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -64,6 +66,18 @@ class Photon(Geocoder):
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
             .. versionadded:: 2.0
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -72,6 +86,8 @@ class Photon(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.domain = domain.strip('/')
         self.api = "%s://%s%s" % (self.scheme, self.domain, self.geocode_path)

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -55,7 +55,7 @@ class PickPoint(Nominatim):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/pickpoint.py
+++ b/geopy/geocoders/pickpoint.py
@@ -24,7 +24,9 @@ class PickPoint(Nominatim):
             scheme=None,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -53,6 +55,16 @@ class PickPoint(Nominatim):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
             .. versionadded:: 2.0
         """
 
@@ -64,6 +76,8 @@ class PickPoint(Nominatim):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
 

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -56,7 +56,7 @@ class LiveAddress(Geocoder):
 
             .. versionadded:: 2.0
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/smartystreets.py
+++ b/geopy/geocoders/smartystreets.py
@@ -28,7 +28,9 @@ class LiveAddress(Geocoder):
             proxies=DEFAULT_SENTINEL,
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
-            adapter_factory=None
+            adapter_factory=None,
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -53,6 +55,18 @@ class LiveAddress(Geocoder):
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
             .. versionadded:: 2.0
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme='https',
@@ -61,6 +75,8 @@ class LiveAddress(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.auth_id = auth_id
         self.auth_token = auth_token

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -30,7 +30,9 @@ class TomTom(Geocoder):
             user_agent=None,
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
-            domain='api.tomtom.com'
+            domain='api.tomtom.com',
+            cache=None,
+            cache_expire=None
     ):
         """
         :param str api_key: TomTom API key.
@@ -58,6 +60,18 @@ class TomTom(Geocoder):
 
         :param str domain: Domain where the target TomTom service
             is hosted.
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -66,6 +80,8 @@ class TomTom(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.api = "%s://%s%s" % (self.scheme, domain, self.geocode_path)

--- a/geopy/geocoders/tomtom.py
+++ b/geopy/geocoders/tomtom.py
@@ -61,7 +61,7 @@ class TomTom(Geocoder):
         :param str domain: Domain where the target TomTom service
             is hosted.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -47,6 +47,8 @@ class What3Words(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain='api.what3words.com',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -74,6 +76,18 @@ class What3Words(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme='https',
@@ -82,6 +96,8 @@ class What3Words(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key
@@ -253,6 +269,8 @@ class What3WordsV3(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain='api.what3words.com',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -278,6 +296,18 @@ class What3WordsV3(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme='https',
@@ -286,6 +316,8 @@ class What3WordsV3(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
 
         self.api_key = api_key

--- a/geopy/geocoders/what3words.py
+++ b/geopy/geocoders/what3words.py
@@ -77,7 +77,7 @@ class What3Words(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
@@ -297,7 +297,7 @@ class What3WordsV3(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/woosmap.py
+++ b/geopy/geocoders/woosmap.py
@@ -66,7 +66,7 @@ class Woosmap(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/woosmap.py
+++ b/geopy/geocoders/woosmap.py
@@ -32,6 +32,8 @@ class Woosmap(Geocoder):
         user_agent=None,
         ssl_context=DEFAULT_SENTINEL,
         adapter_factory=None,
+        cache=None,
+        cache_expire=None
     ):
         """
 
@@ -64,6 +66,17 @@ class Woosmap(Geocoder):
         :param callable adapter_factory:
             See :attr:`geopy.geocoders.options.default_adapter_factory`.
 
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -72,6 +85,8 @@ class Woosmap(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.domain = domain.strip('/')

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -62,7 +62,7 @@ class Yandex(Geocoder):
 
             .. versionadded:: 2.4
 
-        :param cache:
+        :param bool cache:
             Either True or None to activate cache, or False to disable it.
             Default is None. 
             If a a :class:`diskcache.Cache` instance is passed, it will be used as is.

--- a/geopy/geocoders/yandex.py
+++ b/geopy/geocoders/yandex.py
@@ -29,6 +29,8 @@ class Yandex(Geocoder):
             ssl_context=DEFAULT_SENTINEL,
             adapter_factory=None,
             domain='geocode-maps.yandex.ru',
+            cache=None,
+            cache_expire=None
     ):
         """
 
@@ -59,6 +61,18 @@ class Yandex(Geocoder):
         :param str domain: base api domain
 
             .. versionadded:: 2.4
+
+        :param cache:
+            Either True or None to activate cache, or False to disable it.
+            Default is None. 
+            If a a :class:`diskcache.Cache` instance is passed, it will be used as is.
+
+        :param int cache_expire:
+            Time, in seconds, to keep a cached result in memory. 
+            Enables to query again the geocoder in case its database, or algorithm, has changed.
+            Default is 30 days.
+        
+            .. versionadded:: 2.0
         """
         super().__init__(
             scheme=scheme,
@@ -67,6 +81,8 @@ class Yandex(Geocoder):
             user_agent=user_agent,
             ssl_context=ssl_context,
             adapter_factory=adapter_factory,
+            cache=cache,
+            cache_expire=cache_expire
         )
         self.api_key = api_key
         self.api = '%s://%s%s' % (self.scheme, domain, self.api_path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ version = attr: geopy.__version__
 [options]
 install_requires =
     geographiclib<3,>=1.52
-    diskcache>=5.6.3
+
 packages = find:
 python_requires = >=3.7
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ version = attr: geopy.__version__
 [options]
 install_requires =
     geographiclib<3,>=1.52
+    diskcache>=5.6.3
 packages = find:
 python_requires = >=3.7
 

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
             # vendored version of urllib3 (see note above)
         ],
         "timezone": ["pytz"],
+        "diskcache": ["diskcache>=5.6.3"],
     },
 )

--- a/test/geocoders/__init__.py
+++ b/test/geocoders/__init__.py
@@ -310,7 +310,8 @@ def test_no_extra_public_methods(geocoder_cls):
         "geocode",
         "reverse",
         "reverse_timezone",
+        "clear_cache"
     }
     assert methods <= allowed, (
-        "Geopy geocoders are currently allowed to only have these methods: %s" % allowed
+        "Geopy geocoders are currently allowed to only have these methods: %s, but we found those: %s" % (allowed, methods-allowed)
     )

--- a/test/geocoders/arcgis.py
+++ b/test/geocoders/arcgis.py
@@ -19,7 +19,7 @@ class TestArcGIS(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return ArcGIS(timeout=3, **kwargs)
+        return ArcGIS(timeout=3, cache=False, **kwargs)
 
     async def test_missing_password_error(self):
         with pytest.raises(exc.ConfigurationError):
@@ -94,6 +94,7 @@ class TestArcGISAuthenticated(BaseTestGeocoder):
             password=env['ARCGIS_PASSWORD'],
             referer=env['ARCGIS_REFERER'],
             timeout=3,
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/azure.py
+++ b/test/geocoders/azure.py
@@ -8,4 +8,4 @@ class TestAzureMaps(BaseTestTomTom):
     @classmethod
     def make_geocoder(cls, **kwargs):
         return AzureMaps(env['AZURE_SUBSCRIPTION_KEY'], timeout=3,
-                         **kwargs)
+                         cache=False, **kwargs)

--- a/test/geocoders/baidu.py
+++ b/test/geocoders/baidu.py
@@ -13,6 +13,7 @@ class TestUnitBaidu(BaseTestGeocoder):
         return Baidu(
             api_key='DUMMYKEY1234',
             user_agent='my_user_agent/1.0',
+            cache=False,
             **kwargs
         )
 
@@ -49,6 +50,7 @@ class TestBaidu(BaseTestBaidu):
         return Baidu(
             api_key=env['BAIDU_KEY'],
             timeout=3,
+            cache=False,
             **kwargs,
         )
 
@@ -67,6 +69,7 @@ class TestBaiduSK(BaseTestBaidu):
             api_key=env['BAIDU_KEY_REQUIRES_SK'],
             security_key=env['BAIDU_SEC_KEY'],
             timeout=3,
+            cache=False,
             **kwargs,
         )
 
@@ -88,6 +91,7 @@ class TestBaiduV3(TestBaidu):
         return BaiduV3(
             api_key=env['BAIDU_V3_KEY'],
             timeout=3,
+            cache=False,
             **kwargs,
         )
 
@@ -100,5 +104,6 @@ class TestBaiduV3SK(TestBaiduSK):
             api_key=env['BAIDU_V3_KEY_REQUIRES_SK'],
             security_key=env['BAIDU_V3_SEC_KEY'],
             timeout=3,
+            cache=False,
             **kwargs,
         )

--- a/test/geocoders/banfrance.py
+++ b/test/geocoders/banfrance.py
@@ -6,11 +6,12 @@ class TestBANFrance(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return BANFrance(timeout=10, **kwargs)
+        return BANFrance(timeout=10, cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = BANFrance(
-            user_agent='my_user_agent/1.0'
+            user_agent='my_user_agent/1.0',
+            cache=False
         )
         assert geocoder.headers['User-Agent'] == 'my_user_agent/1.0'
 

--- a/test/geocoders/bing.py
+++ b/test/geocoders/bing.py
@@ -19,6 +19,7 @@ class TestBing(BaseTestGeocoder):
     def make_geocoder(cls, **kwargs):
         return Bing(
             api_key=env['BING_KEY'],
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/databc.py
+++ b/test/geocoders/databc.py
@@ -9,7 +9,7 @@ class TestDataBC(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return DataBC(**kwargs)
+        return DataBC(cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = DataBC(

--- a/test/geocoders/geocodeearth.py
+++ b/test/geocoders/geocodeearth.py
@@ -8,4 +8,4 @@ class TestGeocodeEarth(BaseTestPelias):
     @classmethod
     def make_geocoder(cls, **kwargs):
         return GeocodeEarth(env['GEOCODEEARTH_KEY'],
-                            **kwargs)
+                            cache=False, **kwargs)

--- a/test/geocoders/geocodio.py
+++ b/test/geocoders/geocodio.py
@@ -10,7 +10,7 @@ class TestGeocodio(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return Geocodio(api_key=env['GEOCODIO_KEY'], **kwargs)
+        return Geocodio(api_key=env['GEOCODIO_KEY'], cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = self.make_geocoder(user_agent='my_user_agent/1.0')

--- a/test/geocoders/geokeo.py
+++ b/test/geocoders/geokeo.py
@@ -22,6 +22,7 @@ class TestGeokeo(BaseTestGeocoder):
         return Geokeo(
             api_key=env['GEOKEY_KEY'],
             timeout=10,
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/geolake.py
+++ b/test/geocoders/geolake.py
@@ -19,6 +19,7 @@ class TestGeolake(BaseTestGeocoder):
         return Geolake(
             api_key=env['GEOLAKE_KEY'],
             timeout=10,
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/geonames.py
+++ b/test/geocoders/geonames.py
@@ -30,7 +30,7 @@ class TestGeoNames(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return GeoNames(username=env['GEONAMES_USERNAME'], **kwargs)
+        return GeoNames(username=env['GEONAMES_USERNAME'], cache=False, **kwargs)
 
     async def test_geocode(self):
         await self.geocode_run(

--- a/test/geocoders/googlev3.py
+++ b/test/geocoders/googlev3.py
@@ -21,7 +21,7 @@ class TestGoogleV3(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return GoogleV3(api_key=env['GOOGLE_KEY'], **kwargs)
+        return GoogleV3(api_key=env['GOOGLE_KEY'], cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = GoogleV3(

--- a/test/geocoders/here.py
+++ b/test/geocoders/here.py
@@ -189,6 +189,7 @@ class TestHereApiKey(BaseTestHere):
         return Here(
             apikey=env['HERE_APIKEY'],
             timeout=10,
+            cache=False,
             **kwargs
         )
 
@@ -202,6 +203,7 @@ class TestHereLegacyAuth(BaseTestHere):
                 app_id=env['HERE_APP_ID'],
                 app_code=env['HERE_APP_CODE'],
                 timeout=10,
+                cache=False,
                 **kwargs
             )
         assert len(w) == 1
@@ -212,7 +214,7 @@ class TestHereV7(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return HereV7(env['HERE_APIKEY'], **kwargs)
+        return HereV7(env['HERE_APIKEY'], cache=False, **kwargs)
 
     async def test_geocode_empty_result(self):
         await self.geocode_run(

--- a/test/geocoders/ignfrance.py
+++ b/test/geocoders/ignfrance.py
@@ -11,7 +11,8 @@ class TestIGNFrance(BaseTestGeocoder):
     @classmethod
     def make_geocoder(cls, **kwargs):
         return IGNFrance(
-            timeout=10
+            timeout=10,
+            cache=False
         )
 
     async def test_user_agent_custom(self):
@@ -200,6 +201,7 @@ class TestIGNFranceUsernameAuthProxy(BaseTestGeocoder):
     def make_geocoder(cls, **kwargs):
         return IGNFrance(
             timeout=10,
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/mapbox.py
+++ b/test/geocoders/mapbox.py
@@ -8,7 +8,7 @@ from test.geocoders.util import BaseTestGeocoder, env
 class TestMapBox(BaseTestGeocoder):
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return MapBox(api_key=env['MAPBOX_KEY'], timeout=3, **kwargs)
+        return MapBox(api_key=env['MAPBOX_KEY'], timeout=3, cache=False, **kwargs)
 
     async def test_geocode(self):
         await self.geocode_run(

--- a/test/geocoders/mapquest.py
+++ b/test/geocoders/mapquest.py
@@ -6,7 +6,7 @@ from test.geocoders.util import BaseTestGeocoder, env
 class TestMapQuest(BaseTestGeocoder):
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return MapQuest(api_key=env['MAPQUEST_KEY'], timeout=3, **kwargs)
+        return MapQuest(api_key=env['MAPQUEST_KEY'], timeout=3, cache=False, **kwargs)
 
     async def test_geocode(self):
         await self.geocode_run(

--- a/test/geocoders/maptiler.py
+++ b/test/geocoders/maptiler.py
@@ -8,7 +8,7 @@ from test.geocoders.util import BaseTestGeocoder, env
 class TestMapTiler(BaseTestGeocoder):
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return MapTiler(api_key=env['MAPTILER_KEY'], timeout=3, **kwargs)
+        return MapTiler(api_key=env['MAPTILER_KEY'], timeout=3, cache=False, **kwargs)
 
     async def test_geocode(self):
         await self.geocode_run(

--- a/test/geocoders/nominatim.py
+++ b/test/geocoders/nominatim.py
@@ -353,7 +353,7 @@ class TestNominatim(BaseTestNominatim):
     @classmethod
     def make_geocoder(cls, **kwargs):
         kwargs.setdefault('user_agent', 'geopy-test')
-        return Nominatim(**kwargs)
+        return Nominatim(cache=False, **kwargs)
 
     async def test_default_user_agent_error(self):
         with pytest.raises(ConfigurationError):

--- a/test/geocoders/opencage.py
+++ b/test/geocoders/opencage.py
@@ -33,6 +33,7 @@ class TestOpenCage(BaseTestGeocoder):
         return OpenCage(
             api_key=env['OPENCAGE_KEY'],
             timeout=10,
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/openmapquest.py
+++ b/test/geocoders/openmapquest.py
@@ -18,4 +18,4 @@ class TestOpenMapQuest(BaseTestNominatim):
     @classmethod
     def make_geocoder(cls, **kwargs):
         return OpenMapQuest(api_key=env['OPENMAPQUEST_APIKEY'],
-                            timeout=3, **kwargs)
+                            timeout=3, cache=False, **kwargs)

--- a/test/geocoders/pelias.py
+++ b/test/geocoders/pelias.py
@@ -93,5 +93,6 @@ class TestPelias(BaseTestPelias):
         return Pelias(
             env['PELIAS_DOMAIN'],
             api_key=env['PELIAS_KEY'],
+            cache=False,
             **kwargs,
         )

--- a/test/geocoders/photon.py
+++ b/test/geocoders/photon.py
@@ -9,7 +9,7 @@ class TestPhoton(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return Photon(**kwargs)
+        return Photon(cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = Photon(

--- a/test/geocoders/pickpoint.py
+++ b/test/geocoders/pickpoint.py
@@ -10,7 +10,7 @@ class TestPickPoint(BaseTestNominatim):
     @classmethod
     def make_geocoder(cls, **kwargs):
         return PickPoint(api_key=env['PICKPOINT_KEY'],
-                         timeout=3, **kwargs)
+                         timeout=3, cache=False, **kwargs)
 
     async def test_no_nominatim_user_agent_warning(self):
         with warnings.catch_warnings(record=True) as w:

--- a/test/geocoders/smartystreets.py
+++ b/test/geocoders/smartystreets.py
@@ -30,6 +30,7 @@ class TestLiveAddress(BaseTestGeocoder):
         return LiveAddress(
             auth_id=env['LIVESTREETS_AUTH_ID'],
             auth_token=env['LIVESTREETS_AUTH_TOKEN'],
+            cache=False,
             **kwargs
         )
 

--- a/test/geocoders/tomtom.py
+++ b/test/geocoders/tomtom.py
@@ -47,4 +47,4 @@ class TestTomTom(BaseTestTomTom):
     @classmethod
     def make_geocoder(cls, **kwargs):
         return TomTom(env['TOMTOM_KEY'], timeout=3,
-                      **kwargs)
+                      cache=False, **kwargs)

--- a/test/geocoders/what3words.py
+++ b/test/geocoders/what3words.py
@@ -91,6 +91,7 @@ class TestWhat3Words(BaseTestWhat3Words):
         return What3Words(
             env['WHAT3WORDS_KEY'],
             timeout=3,
+            cache=False,
             **kwargs
         )
 
@@ -107,5 +108,6 @@ class TestWhat3WordsV3(BaseTestWhat3Words):
         return What3WordsV3(
             env['WHAT3WORDS_KEY'],
             timeout=3,
+            cache=False,
             **kwargs
         )

--- a/test/geocoders/woosmap.py
+++ b/test/geocoders/woosmap.py
@@ -9,7 +9,7 @@ from test.geocoders.util import BaseTestGeocoder, env
 class TestWoosmap(BaseTestGeocoder):
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return Woosmap(api_key=env['WOOSMAP_KEY'], **kwargs)
+        return Woosmap(api_key=env['WOOSMAP_KEY'], cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = Woosmap(

--- a/test/geocoders/yandex.py
+++ b/test/geocoders/yandex.py
@@ -9,7 +9,7 @@ class TestYandex(BaseTestGeocoder):
 
     @classmethod
     def make_geocoder(cls, **kwargs):
-        return Yandex(api_key=env['YANDEX_KEY'], **kwargs)
+        return Yandex(api_key=env['YANDEX_KEY'], cache=False, **kwargs)
 
     async def test_user_agent_custom(self):
         geocoder = Yandex(


### PR DESCRIPTION
See issue #6 

We propose here a caching principle based on `diskcache`. Caching is implemented in the base class. In order to enable users to deal with cache, we had to add new parameters to the constructors, and another public function for cache clearing. 
